### PR TITLE
fix(phoenixclaw): support nested message.timestamp and Unix milliseconds format

### DIFF
--- a/skills/phoenixclaw/references/session-day-audit.js
+++ b/skills/phoenixclaw/references/session-day-audit.js
@@ -125,7 +125,37 @@ function safeJsonParse(line, file, lineNumber) {
 }
 
 function getTimestamp(entry) {
-  const ts = entry.timestamp || entry.created_at;
+  // Try multiple timestamp sources (OpenClaw format and legacy)
+  let ts = entry.timestamp || entry.created_at;
+  
+  // Fallback to nested message.timestamp (OpenClaw session logs)
+  if (!ts && entry.message?.timestamp) {
+    ts = entry.message.timestamp;
+  }
+  
+  if (ts === null || ts === undefined) {
+    return null;
+  }
+  
+  // Handle Unix milliseconds (number format)
+  if (typeof ts === "number") {
+    // Detect if it's milliseconds (> year 2000 in ms = 946684800000)
+    if (ts > 946684800000) {
+      const d = new Date(ts);
+      if (Number.isNaN(d.getTime())) {
+        return null;
+      }
+      return d;
+    }
+    // Assume seconds if smaller number
+    const d = new Date(ts * 1000);
+    if (Number.isNaN(d.getTime())) {
+      return null;
+    }
+    return d;
+  }
+  
+  // Handle string format
   if (typeof ts !== "string" || ts.length === 0) {
     return null;
   }


### PR DESCRIPTION
## 修复内容

本次 PR 解决了 PhoenixClaw 在多 agents 架构下的会话日志扫描 bug。

### 🔧 主要修改

**session-day-audit.js - getTimestamp() 函数增强**:

1. **支持嵌套时间戳格式**
   - 新增 fallback 到 `entry.message.timestamp`
   - 适配 OpenClaw 会话日志的嵌套结构

2. **支持 Unix 时间戳格式**
   - 自动检测 Unix 毫秒格式（数字 > 946684800000）
   - 支持 Unix 秒格式（较小数字）
   - 解决时间戳解析不完整问题

### 📋 问题背景

在多 agents 架构下，会话日志可能使用不同的时间戳存储格式：
- 传统格式：`entry.timestamp` (ISO 字符串)
- OpenClaw 格式：`entry.message.timestamp` (嵌套)
- Unix 格式：数字（毫秒或秒）

之前的代码只支持 ISO 字符串格式，导致部分会话消息无法被正确扫描。

### 🔒 兼容性

- ✅ 向后兼容现有 ISO 字符串格式
- ✅ 新增嵌套格式支持
- ✅ 新增 Unix 时间戳支持
- ✅ 无破坏性变更

### 🧪 测试

已在本地验证会话扫描功能正常，可正确识别多种时间戳格式的消息。

---
**版本**: 0.0.18 → 0.0.19
**相关 Issue**: 多 agent 会话扫描 bug 修复