### PR TITLE
fix: add missing session scan paths for multi-agent architecture

### DIFF
--- a/skills/openclaw-visual/SKILL.md
+++ b/skills/openclaw-visual/SKILL.md
@@ -391,7 +391,7 @@ AI:
 用户: "把今天的对话做成总结图"
 
 AI:
-1. 扫描 `~/.openclaw/sessions/` 今日记录
+1. 扫描所有 session 路径 (`~/.openclaw/sessions/`, `~/.openclaw/agents/`, `~/.openclaw/cron/runs/`, `~/.agent/sessions/`) 今日记录
 2. 提取关键话题和决策
 3. 选择 `dashboard` 或 `social-share` 模板
 4. 生成并发送图片

--- a/skills/openclaw-visual/references/content-parsing.md
+++ b/skills/openclaw-visual/references/content-parsing.md
@@ -59,7 +59,7 @@ energy: high
 
 **解析步骤:**
 1. 确定日期范围
-2. 扫描 `~/.openclaw/sessions/*.jsonl`
+2. 扫描所有 session 路径 (`~/.openclaw/sessions/*.jsonl`, `~/.openclaw/agents/`, `~/.openclaw/cron/runs/`, `~/.agent/sessions/`)
 3. 按时间戳过滤消息
 4. 提取关键话题和决策
 5. 统计情绪/能量趋势

--- a/skills/phoenixclaw/SKILL.md
+++ b/skills/phoenixclaw/SKILL.md
@@ -39,7 +39,7 @@ PhoenixClaw follows a structured pipeline to ensure consistency and depth:
    - Call `memory_get` for the current day's memory
    - **CRITICAL: Scan ALL raw session logs and filter by message timestamp**. Session files are often split across multiple files. Do NOT classify images by session file `mtime`:
       ```bash
-      # Read all session logs from both OpenClaw locations, then filter by per-message timestamp
+      # Read all session logs from all OpenClaw locations (multi-agent support), then filter by per-message timestamp
       # Use timezone-aware epoch range to avoid UTC/local-day mismatches.
       TARGET_DAY="$(date +%Y-%m-%d)"
       TARGET_TZ="${TARGET_TZ:-Asia/Shanghai}"
@@ -56,7 +56,8 @@ print(int(start.timestamp()), int(end.timestamp()))
 PY
       )
 
-      for dir in "$HOME/.openclaw/sessions" "$HOME/.agent/sessions"; do
+      # Scan ALL session directories (multi-agent architecture support)
+      for dir in "$HOME/.openclaw/sessions" "$HOME/.openclaw/agents" "$HOME/.openclaw/cron/runs" "$HOME/.agent/sessions"; do
         [ -d "$dir" ] || continue
         find "$dir" -name "*.jsonl" -print0
       done |

--- a/skills/phoenixclaw/references/cron-setup.md
+++ b/skills/phoenixclaw/references/cron-setup.md
@@ -21,7 +21,7 @@ openclaw cron add \
 NEVER skip session log scanning - images are ONLY there. NEVER skip step 3 - plugins depend on moments data."
 ```
 
-> **Memory & Session Scan**: Always scan session logs (`~/.openclaw/sessions/*.jsonl` or `.agent/sessions/`) alongside daily memory to capture in-progress activity. If daily memory is missing or sparse, use session logs to reconstruct context, then update daily memory.
+> **Memory & Session Scan**: Always scan session logs from ALL paths (`~/.openclaw/sessions/*.jsonl`, `~/.openclaw/agents/`, `~/.openclaw/cron/runs/`, or `~/.agent/sessions/`) alongside daily memory to capture in-progress activity. If daily memory is missing or sparse, use session logs to reconstruct context, then update daily memory.
 
 ### Configuration Details
 - **--name**: Unique identifier for the job. Useful for management.
@@ -77,7 +77,8 @@ print(int(start.timestamp()), int(end.timestamp()))
 PY
 )
 
-for dir in "$HOME/.openclaw/sessions" "$HOME/.agent/sessions"; do
+# Scan ALL session directories (multi-agent architecture support)
+for dir in "$HOME/.openclaw/sessions" "$HOME/.openclaw/agents" "$HOME/.openclaw/cron/runs" "$HOME/.agent/sessions"; do
   [ -d "$dir" ] || continue
   find "$dir" -name "*.jsonl" -print0
 done |

--- a/skills/phoenixclaw/references/media-handling.md
+++ b/skills/phoenixclaw/references/media-handling.md
@@ -42,8 +42,8 @@ print(int(start.timestamp()), int(end.timestamp()))
 PY
 )
 
-# Step 3: Read all session files from both locations and keep only messages inside TARGET_DAY
-for dir in "$HOME/.openclaw/sessions" "$HOME/.agent/sessions"; do
+# Step 3: Read all session files from all locations (multi-agent support) and keep only messages inside TARGET_DAY
+for dir in "$HOME/.openclaw/sessions" "$HOME/.openclaw/agents" "$HOME/.openclaw/cron/runs" "$HOME/.agent/sessions"; do
   [ -d "$dir" ] || continue
   find "$dir" -name "*.jsonl" -print0
 done |
@@ -56,8 +56,8 @@ done |
 
 **Extract image entries from target-day messages:**
 ```bash
-# Keep image entries whose message timestamp is in TARGET_DAY
-for dir in "$HOME/.openclaw/sessions" "$HOME/.agent/sessions"; do
+# Keep image entries whose message timestamp is in TARGET_DAY (multi-agent support)
+for dir in "$HOME/.openclaw/sessions" "$HOME/.openclaw/agents" "$HOME/.openclaw/cron/runs" "$HOME/.agent/sessions"; do
   [ -d "$dir" ] || continue
   find "$dir" -name "*.jsonl" -print0
 done |


### PR DESCRIPTION
## Problem

In multi-agent architectures, session logs are stored in multiple directories:
- `~/.openclaw/sessions` - main session logs
- `~/.openclaw/agents` - agent-specific sessions
- `~/.openclaw/cron/runs` - cron-triggered session logs
- `~/.agent/sessions` - legacy agent sessions

The documentation and shell command examples only referenced 2 out of 4 paths (`~/.openclaw/sessions` and `~/.agent/sessions`), causing:
- Missing messages in daily journal generation
- Missing images in journal entries
- Incomplete chat summaries
- Failed session scanning for multi-agent setups

## Solution

Updated all documentation and shell command examples to scan ALL session directories:

**Files changed:**
- `skills/phoenixclaw/SKILL.md` - Core workflow session scanning
- `skills/phoenixclaw/references/cron-setup.md` - Cron verification commands
- `skills/phoenixclaw/references/media-handling.md` - Image extraction commands
- `skills/openclaw-visual/SKILL.md` - Chat summary scanning
- `skills/openclaw-visual/references/content-parsing.md` - Content parsing docs

**Note:** The `session-day-audit.js` utility already had the correct paths implemented; this PR aligns the documentation with the existing implementation.

## Testing

Run the session-day-audit utility to verify all paths are scanned:
```bash
node skills/phoenixclaw/references/session-day-audit.js --day $(date +%Y-%m-%d) --verbose
```

## Related

Fixes multi-agent session scanning issues reported in issue discussions.