### PR TITLE
fix(openclaw-visual): update session scan paths for multi-agent support

### DIFF
--- a/skills/openclaw-visual/SKILL.md
+++ b/skills/openclaw-visual/SKILL.md
@@ -391,7 +391,7 @@ AI:
 用户: "把今天的对话做成总结图"
 
 AI:
-1. 扫描 `~/.openclaw/sessions/` 今日记录
+1. 扫描所有 session 路径（`~/.openclaw/sessions/`, `~/.openclaw/agents/`, `~/.openclaw/cron/runs/`, `~/.agent/sessions/`）今日记录
 2. 提取关键话题和决策
 3. 选择 `dashboard` 或 `social-share` 模板
 4. 生成并发送图片

--- a/skills/openclaw-visual/references/content-parsing.md
+++ b/skills/openclaw-visual/references/content-parsing.md
@@ -59,7 +59,7 @@ energy: high
 
 **解析步骤:**
 1. 确定日期范围
-2. 扫描 `~/.openclaw/sessions/*.jsonl`
+2. 扫描所有 session 路径（`~/.openclaw/sessions/*.jsonl`, `~/.openclaw/agents/`, `~/.openclaw/cron/runs/`, `~/.agent/sessions/`）
 3. 按时间戳过滤消息
 4. 提取关键话题和决策
 5. 统计情绪/能量趋势


### PR DESCRIPTION
## Problem

The openclaw-visual skill documentation only referenced `~/.openclaw/sessions/` for chat summary scanning, missing messages from:
- `~/.openclaw/agents/` - agent-specific sessions
- `~/.openclaw/cron/runs/` - cron-triggered sessions
- `~/.agent/sessions/` - legacy agent sessions

## Solution

Updated documentation to include all 4 session paths, matching the PhoenixClaw core implementation.

## Files Changed

- `skills/openclaw-visual/SKILL.md`
- `skills/openclaw-visual/references/content-parsing.md`

## Impact

Ensures chat summary visualization captures all messages across multi-agent architectures.